### PR TITLE
Parsing xml files with slightly differing spec of ImageLoader format "bdv.multimg.zarr"

### DIFF
--- a/src/pydantic_bigstitcher/__init__.py
+++ b/src/pydantic_bigstitcher/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal, Optional
+from typing import Literal
 
 from xml.etree.ElementTree import Element, fromstring, tostring
 from pydantic import model_validator, PrivateAttr
@@ -36,7 +36,7 @@ class ZGroupD(BaseXmlModel, tag="zgroup"):
     setup: str = attr()
     path: str = attr()
     tp: str = attr()
-    indicies: Optional[str] = attr(default=None)
+    indicies: str | None = attr(default=None)
 
 ZGroup = ZGroupA | ZGroupB | ZGroupC | ZGroupD
 

--- a/src/pydantic_bigstitcher/__init__.py
+++ b/src/pydantic_bigstitcher/__init__.py
@@ -36,8 +36,7 @@ class ZGroupD(BaseXmlModel, tag="zgroup"):
     setup: str = attr()
     path: str = attr()
     tp: str = attr()
-    indicies: str = attr()
-
+    indicies: Optional[str] = attr(default=None)
 
 ZGroup = ZGroupA | ZGroupB | ZGroupC | ZGroupD
 

--- a/src/pydantic_bigstitcher/__init__.py
+++ b/src/pydantic_bigstitcher/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Literal
 
 from xml.etree.ElementTree import Element, fromstring, tostring
-from pydantic import model_validator, PrivateAttr
+from pydantic import PrivateAttr, ConfigDict
 from pydantic_xml import BaseXmlModel, attr, element
 
 from pydantic_bigstitcher.transform import AffineViewTransform
@@ -15,30 +15,47 @@ class BasePath(BaseXmlModel):
 
 
 class ZGroupA(BaseXmlModel, tag="zgroup"):
+    model_config = ConfigDict(extra="forbid")
     setup: str = attr()
     path: str = element()
     timepoint: str = attr()
 
 
 class ZGroupB(BaseXmlModel, tag="zgroup"):
+    model_config = ConfigDict(extra="forbid")
     setup: str = attr()
     path: str = element()
     tp: str = attr()
     
 
 class ZGroupC(BaseXmlModel, tag="zgroup"):
+    model_config = ConfigDict(extra="forbid")
     setup: str = attr()
     path: str = attr()
     timepoint: str = attr()
     
 
 class ZGroupD(BaseXmlModel, tag="zgroup"):
+    model_config = ConfigDict(extra="forbid")
     setup: str = attr()
     path: str = attr()
     tp: str = attr()
-    indicies: str | None = attr(default=None)
 
-ZGroup = ZGroupA | ZGroupB | ZGroupC | ZGroupD
+
+class ZGroupE(BaseXmlModel, tag="zgroup"):
+    model_config = ConfigDict(extra="forbid")
+    setup: str = attr()
+    path: str = attr()
+    tp: str = attr()
+    indicies: str = attr()
+
+
+# Groups A-D capture:
+# 1. "tp" or "timepoint" attribute
+# 2. "path" as element or attribute
+# Group E captures an additional "indicies" attribute
+# as found in the mesospim example XML (bigstitcher_6.xml)
+ZGroup = ZGroupA | ZGroupB | ZGroupC | ZGroupD | ZGroupE
 
 
 class ZGroups(BaseXmlModel, tag="zgroups"):

--- a/src/pydantic_bigstitcher/__init__.py
+++ b/src/pydantic_bigstitcher/__init__.py
@@ -14,49 +14,35 @@ class BasePath(BaseXmlModel):
     path: str
 
 
-class ZGroupPathAsElement(BaseXmlModel, tag="zgroup"):
+class ZGroupA(BaseXmlModel, tag="zgroup"):
     setup: str = attr()
     path: str = element()
+    timepoint: str = attr()
 
-    # both timepoint and tp are accepted
-    timepoint: Optional[str] = attr(name="timepoint", default=None)
-    tp: Optional[str] = attr(name="tp", default=None, exclude=True)
 
-    @model_validator(mode="after")
-    def _coalesce_timepoint(self):
-        # prefer explicit 'timepoint', fall back to 'tp'
-        if self.timepoint is None and self.tp is not None:
-            self.timepoint = self.tp
-        # (optional) detect conflicting inputs
-        if self.timepoint is not None and self.tp is not None and self.timepoint != self.tp:
-            raise ValueError('Attributes "timepoint" and "tp" disagree.')
-        if self.timepoint is None:
-            raise ValueError('Provide either "timepoint" or "tp".')
-        return self
+class ZGroupB(BaseXmlModel, tag="zgroup"):
+    setup: str = attr()
+    path: str = element()
+    tp: str = attr()
     
 
-class ZGroupPathAsAttribute(BaseXmlModel, tag="zgroup"):
+class ZGroupC(BaseXmlModel, tag="zgroup"):
     setup: str = attr()
     path: str = attr()
+    timepoint: str = attr()
+    
 
-    timepoint: Optional[str] = attr(name="timepoint", default=None)
-    tp: Optional[str] = attr(name="tp", default=None, exclude=True)
-
-    @model_validator(mode="after")
-    def _coalesce_timepoint(self):
-        # prefer explicit 'timepoint', fall back to 'tp'
-        if self.timepoint is None and self.tp is not None:
-            self.timepoint = self.tp
-        # (optional) detect conflicting inputs
-        if self.timepoint is not None and self.tp is not None and self.timepoint != self.tp:
-            raise ValueError('Attributes "timepoint" and "tp" disagree.')
-        if self.timepoint is None:
-            raise ValueError('Provide either "timepoint" or "tp".')
-        return self
+class ZGroupD(BaseXmlModel, tag="zgroup"):
+    setup: str = attr()
+    path: str = attr()
+    tp: str = attr()
 
 
-class ZGroups(BaseXmlModel):
-    elements: list[ZGroupPathAsElement | ZGroupPathAsAttribute] = element(tag="zgroup")
+ZGroup = ZGroupA | ZGroupB | ZGroupC | ZGroupD
+
+
+class ZGroups(BaseXmlModel, tag="zgroups"):
+    elements: list[ZGroup] = element(tag="zgroup")
 
 
 class Zarr(BaseXmlModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def bigstitcher_xml(request: pytest.FixtureRequest) -> str:
     fname = f"tests/fixture/bigstitcher_{request.param}.xml"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def bigstitcher_xml(request: pytest.FixtureRequest) -> str:
     fname = f"tests/fixture/bigstitcher_{request.param}.xml"
 

--- a/tests/fixture/bigstitcher_6.xml
+++ b/tests/fixture/bigstitcher_6.xml
@@ -1,0 +1,583 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file was shared by Nikita Vladimirov:
+https://forum.image.sc/t/are-there-publicly-available-mesospim-datasets-unprocessed/116020/9?u=malbert
+
+Copied description:
+- 2 channels, 2x2 tiles grid, 2 illumination arms, unstitched
+- channels: 488, 561 nm, for staining details see tutorial links below
+- mouse brain cleared by Anna Maria Reuss (UZH/USZ), iDISCO protocol.
+- OME-ZARR with optional XML file to open it eg in BigStitcher
+- BigStitcher tutorial on this particular data: https://www.youtube.com/watch?v=fWseoLI_2jg
+-->
+<SpimData version="0.2">
+  <generatedBy>
+    <library version="2021.03">npy2bdv</library>
+    <microscope>
+      <name>default</name>
+      <version>0.0</version>
+      <user>user</user>
+    </microscope>
+  </generatedBy>
+  <BasePath type="relative">.</BasePath>
+  <SequenceDescription>
+    <ImageLoader format="bdv.multimg.zarr" version="3.0">
+      <zarr type="relative">Reuss-MousBrain2x2tiles-2ch.ome.zarr</zarr>
+      <zgroups>
+        <zgroup setup="0" tp="0" path="s0-t0.zarr" indicies="0 0" />
+        <zgroup setup="1" tp="0" path="s1-t0.zarr" indicies="0 0" />
+        <zgroup setup="2" tp="0" path="s2-t0.zarr" indicies="0 0" />
+        <zgroup setup="3" tp="0" path="s3-t0.zarr" indicies="0 0" />
+        <zgroup setup="4" tp="0" path="s4-t0.zarr" indicies="0 0" />
+        <zgroup setup="5" tp="0" path="s5-t0.zarr" indicies="0 0" />
+        <zgroup setup="6" tp="0" path="s6-t0.zarr" indicies="0 0" />
+        <zgroup setup="7" tp="0" path="s7-t0.zarr" indicies="0 0" />
+        <zgroup setup="8" tp="0" path="s8-t0.zarr" indicies="0 0" />
+        <zgroup setup="9" tp="0" path="s9-t0.zarr" indicies="0 0" />
+        <zgroup setup="10" tp="0" path="s10-t0.zarr" indicies="0 0" />
+        <zgroup setup="11" tp="0" path="s11-t0.zarr" indicies="0 0" />
+        <zgroup setup="12" tp="0" path="s12-t0.zarr" indicies="0 0" />
+        <zgroup setup="13" tp="0" path="s13-t0.zarr" indicies="0 0" />
+        <zgroup setup="14" tp="0" path="s14-t0.zarr" indicies="0 0" />
+        <zgroup setup="15" tp="0" path="s15-t0.zarr" indicies="0 0" />
+      </zgroups>
+    </ImageLoader>
+    <ViewSetups>
+      <ViewSetup>
+        <id>0</id>
+        <camera>
+          <name>default</name>
+          <exposureTime>0</exposureTime>
+          <exposureUnits>s</exposureUnits>
+        </camera>
+        <name>setup 0</name>
+        <size>2048 2048 615</size>
+        <voxelSize>
+          <unit>um</unit>
+          <size>3.26 3.26 10.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>0</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>1</id>
+        <camera>
+          <name>default</name>
+          <exposureTime>0</exposureTime>
+          <exposureUnits>s</exposureUnits>
+        </camera>
+        <name>setup 1</name>
+        <size>2048 2048 615</size>
+        <voxelSize>
+          <unit>um</unit>
+          <size>3.26 3.26 10.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>1</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>2</id>
+        <camera>
+          <name>default</name>
+          <exposureTime>0</exposureTime>
+          <exposureUnits>s</exposureUnits>
+        </camera>
+        <name>setup 2</name>
+        <size>2048 2048 615</size>
+        <voxelSize>
+          <unit>um</unit>
+          <size>3.26 3.26 10.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>2</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>3</id>
+        <camera>
+          <name>default</name>
+          <exposureTime>0</exposureTime>
+          <exposureUnits>s</exposureUnits>
+        </camera>
+        <name>setup 3</name>
+        <size>2048 2048 615</size>
+        <voxelSize>
+          <unit>um</unit>
+          <size>3.26 3.26 10.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>0</channel>
+          <tile>3</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>4</id>
+        <camera>
+          <name>default</name>
+          <exposureTime>0</exposureTime>
+          <exposureUnits>s</exposureUnits>
+        </camera>
+        <name>setup 4</name>
+        <size>2048 2048 615</size>
+        <voxelSize>
+          <unit>um</unit>
+          <size>3.26 3.26 10.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>1</channel>
+          <tile>0</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>5</id>
+        <camera>
+          <name>default</name>
+          <exposureTime>0</exposureTime>
+          <exposureUnits>s</exposureUnits>
+        </camera>
+        <name>setup 5</name>
+        <size>2048 2048 615</size>
+        <voxelSize>
+          <unit>um</unit>
+          <size>3.26 3.26 10.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>1</channel>
+          <tile>1</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>6</id>
+        <camera>
+          <name>default</name>
+          <exposureTime>0</exposureTime>
+          <exposureUnits>s</exposureUnits>
+        </camera>
+        <name>setup 6</name>
+        <size>2048 2048 615</size>
+        <voxelSize>
+          <unit>um</unit>
+          <size>3.26 3.26 10.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>1</channel>
+          <tile>2</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>7</id>
+        <camera>
+          <name>default</name>
+          <exposureTime>0</exposureTime>
+          <exposureUnits>s</exposureUnits>
+        </camera>
+        <name>setup 7</name>
+        <size>2048 2048 615</size>
+        <voxelSize>
+          <unit>um</unit>
+          <size>3.26 3.26 10.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>0</illumination>
+          <channel>1</channel>
+          <tile>3</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>8</id>
+        <camera>
+          <name>default</name>
+          <exposureTime>0</exposureTime>
+          <exposureUnits>s</exposureUnits>
+        </camera>
+        <name>setup 8</name>
+        <size>2048 2048 615</size>
+        <voxelSize>
+          <unit>um</unit>
+          <size>3.26 3.26 10.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>1</illumination>
+          <channel>0</channel>
+          <tile>0</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>9</id>
+        <camera>
+          <name>default</name>
+          <exposureTime>0</exposureTime>
+          <exposureUnits>s</exposureUnits>
+        </camera>
+        <name>setup 9</name>
+        <size>2048 2048 615</size>
+        <voxelSize>
+          <unit>um</unit>
+          <size>3.26 3.26 10.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>1</illumination>
+          <channel>0</channel>
+          <tile>1</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>10</id>
+        <camera>
+          <name>default</name>
+          <exposureTime>0</exposureTime>
+          <exposureUnits>s</exposureUnits>
+        </camera>
+        <name>setup 10</name>
+        <size>2048 2048 615</size>
+        <voxelSize>
+          <unit>um</unit>
+          <size>3.26 3.26 10.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>1</illumination>
+          <channel>0</channel>
+          <tile>2</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>11</id>
+        <camera>
+          <name>default</name>
+          <exposureTime>0</exposureTime>
+          <exposureUnits>s</exposureUnits>
+        </camera>
+        <name>setup 11</name>
+        <size>2048 2048 615</size>
+        <voxelSize>
+          <unit>um</unit>
+          <size>3.26 3.26 10.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>1</illumination>
+          <channel>0</channel>
+          <tile>3</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>12</id>
+        <camera>
+          <name>default</name>
+          <exposureTime>0</exposureTime>
+          <exposureUnits>s</exposureUnits>
+        </camera>
+        <name>setup 12</name>
+        <size>2048 2048 615</size>
+        <voxelSize>
+          <unit>um</unit>
+          <size>3.26 3.26 10.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>1</illumination>
+          <channel>1</channel>
+          <tile>0</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>13</id>
+        <camera>
+          <name>default</name>
+          <exposureTime>0</exposureTime>
+          <exposureUnits>s</exposureUnits>
+        </camera>
+        <name>setup 13</name>
+        <size>2048 2048 615</size>
+        <voxelSize>
+          <unit>um</unit>
+          <size>3.26 3.26 10.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>1</illumination>
+          <channel>1</channel>
+          <tile>1</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>14</id>
+        <camera>
+          <name>default</name>
+          <exposureTime>0</exposureTime>
+          <exposureUnits>s</exposureUnits>
+        </camera>
+        <name>setup 14</name>
+        <size>2048 2048 615</size>
+        <voxelSize>
+          <unit>um</unit>
+          <size>3.26 3.26 10.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>1</illumination>
+          <channel>1</channel>
+          <tile>2</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <ViewSetup>
+        <id>15</id>
+        <camera>
+          <name>default</name>
+          <exposureTime>0</exposureTime>
+          <exposureUnits>s</exposureUnits>
+        </camera>
+        <name>setup 15</name>
+        <size>2048 2048 615</size>
+        <voxelSize>
+          <unit>um</unit>
+          <size>3.26 3.26 10.0</size>
+        </voxelSize>
+        <attributes>
+          <illumination>1</illumination>
+          <channel>1</channel>
+          <tile>3</tile>
+          <angle>0</angle>
+        </attributes>
+      </ViewSetup>
+      <Attributes name="illumination">
+        <Illumination>
+          <id>0</id>
+          <name>Left</name>
+        </Illumination>
+        <Illumination>
+          <id>1</id>
+          <name>Right</name>
+        </Illumination>
+      </Attributes>
+      <Attributes name="channel">
+        <Channel>
+          <id>0</id>
+          <name>488 nm</name>
+        </Channel>
+        <Channel>
+          <id>1</id>
+          <name>561 nm</name>
+        </Channel>
+      </Attributes>
+      <Attributes name="tile">
+        <Tile>
+          <id>0</id>
+          <name>0</name>
+        </Tile>
+        <Tile>
+          <id>1</id>
+          <name>1</name>
+        </Tile>
+        <Tile>
+          <id>2</id>
+          <name>2</name>
+        </Tile>
+        <Tile>
+          <id>3</id>
+          <name>3</name>
+        </Tile>
+      </Attributes>
+      <Attributes name="angle">
+        <Angle>
+          <id>0</id>
+          <name>0.0</name>
+        </Angle>
+      </Attributes>
+    </ViewSetups>
+    <Timepoints type="pattern">
+      <integerpattern>0</integerpattern>
+    </Timepoints>
+    <MissingViews />
+  </SequenceDescription>
+  <ViewRegistrations>
+    <ViewRegistration timepoint="0" setup="0">
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -861.5031 0.0 1.0 0.0 23895.71 0.0 0.0 1.0 6145.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.067484662576687 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="1">
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -861.5031 0.0 1.0 0.0 25585.28 0.0 0.0 1.0 6145.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.067484662576687 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="2">
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 674.6933 0.0 1.0 0.0 23895.71 0.0 0.0 1.0 6145.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.067484662576687 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="3">
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 674.6933 0.0 1.0 0.0 25585.28 0.0 0.0 1.0 6145.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.067484662576687 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="4">
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -861.5031 0.0 1.0 0.0 23895.71 0.0 0.0 1.0 6145.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.067484662576687 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="5">
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -861.5031 0.0 1.0 0.0 25585.28 0.0 0.0 1.0 6145.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.067484662576687 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="6">
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 674.6933 0.0 1.0 0.0 23895.71 0.0 0.0 1.0 6145.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.067484662576687 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="7">
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 674.6933 0.0 1.0 0.0 25585.28 0.0 0.0 1.0 6145.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.067484662576687 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="8">
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -861.5031 0.0 1.0 0.0 23895.71 0.0 0.0 1.0 6145.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.067484662576687 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="9">
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -861.5031 0.0 1.0 0.0 25585.28 0.0 0.0 1.0 6145.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.067484662576687 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="10">
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 674.6933 0.0 1.0 0.0 23895.71 0.0 0.0 1.0 6145.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.067484662576687 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="11">
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 674.6933 0.0 1.0 0.0 25585.28 0.0 0.0 1.0 6145.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.067484662576687 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="12">
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -861.5031 0.0 1.0 0.0 23895.71 0.0 0.0 1.0 6145.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.067484662576687 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="13">
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 -861.5031 0.0 1.0 0.0 25585.28 0.0 0.0 1.0 6145.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.067484662576687 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="14">
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 674.6933 0.0 1.0 0.0 23895.71 0.0 0.0 1.0 6145.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.067484662576687 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+    <ViewRegistration timepoint="0" setup="15">
+      <ViewTransform type="affine">
+        <Name>Translation to Regular Grid</Name>
+        <affine>1.0 0.0 0.0 674.6933 0.0 1.0 0.0 25585.28 0.0 0.0 1.0 6145.0</affine>
+      </ViewTransform>
+      <ViewTransform type="affine">
+        <Name>calibration</Name>
+        <affine>1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 3.067484662576687 0.0</affine>
+      </ViewTransform>
+    </ViewRegistration>
+  </ViewRegistrations>
+  <ViewInterestPoints />
+  <BoundingBoxes />
+  <PointSpreadFunctions />
+  <StitchingResults />
+  <IntensityAdjustments />
+</SpimData>

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -218,7 +218,7 @@ def test_decode_view_interest_points() -> None:
     assert diff_result == []
 
 
-@pytest.mark.parametrize("bigstitcher_xml", (0, 1, 2, 3, 4, 5), indirect=True)
+@pytest.mark.parametrize("bigstitcher_xml", (0, 1, 2, 3, 4, 5, 6), indirect=True)
 @pytest.mark.parametrize(
     "attribute_path, model_class",
     [
@@ -242,7 +242,7 @@ def test_view_setups(bigstitcher_xml: str, attribute_path: str, model_class: Bas
     assert observed == expected
 
 
-@pytest.mark.parametrize("bigstitcher_xml", (0, 1, 2, 3, 4, 5), indirect=True)
+@pytest.mark.parametrize("bigstitcher_xml", (0, 1, 2, 3, 4, 5, 6), indirect=True)
 def test_encode_decode_dict(bigstitcher_xml: str) -> None:
     model = SpimData2.from_xml(bigstitcher_xml.encode())
     observed = xmltodict.parse(model.to_xml())

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,8 +15,7 @@ from pydantic_bigstitcher import (
     ViewInterestPoints,
     ViewRegistrations,
     ZarrImageLoader,
-    ZGroupPathAsAttribute,
-    ZGroupPathAsElement,
+    ZGroups,
 )
 from pydantic_bigstitcher.transform import (
     AffineViewTransform,
@@ -92,22 +91,32 @@ def test_decode_zarr_image_loader_2() -> None:
     assert diff_result == []
 
 
-def test_decode_zgrouppathaselement() -> None:
-    data = """
+@pytest.mark.parametrize(
+    "data",
+    [
+        """
         <zgroup setup="0" timepoint="0">
           <path>tile_x_0000_y_0000_z_0000_ch_488.zarr</path>
-        </zgroup>"""
-    observed = xmltodict.parse(ZGroupPathAsElement.from_xml(data).to_xml())
-    expected = xmltodict.parse(data)
-    diff = deepdiff.diff.DeepDiff(observed, expected)
-    assert diff == {}
-
-
-def test_decode_zgrouppathasattribute() -> None:
-    data = """
+        </zgroup>
+        """,
+        """
         <zgroup setup="0" timepoint="0" path="tile_x_0000_y_0000_z_0000_ch_488.zarr">
-        </zgroup>"""
-    observed = xmltodict.parse(ZGroupPathAsAttribute.from_xml(data).to_xml())
+        </zgroup>
+        """,
+        """
+        <zgroup setup="0" tp="0">
+          <path>tile_x_0000_y_0000_z_0000_ch_488.zarr</path>
+        </zgroup>
+        """,
+        """
+        <zgroup setup="0" tp="0" path="tile_x_0000_y_0000_z_0000_ch_488.zarr">
+        </zgroup>
+        """,
+    ],
+)
+def test_decode_zgroups(data) -> None:
+    data = "<zgroups>" + data + "</zgroups>"
+    observed = xmltodict.parse(ZGroups.from_xml(data).to_xml())
     expected = xmltodict.parse(data)
     diff = deepdiff.diff.DeepDiff(observed, expected)
     assert diff == {}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -239,7 +239,8 @@ def test_view_setups(bigstitcher_xml: str, attribute_path: str, model_class: Bas
     model = model_class.from_xml(subnode_str)
     observed = xmltodict.parse(model.to_xml())
     expected = xmltodict.parse(subnode_str)
-    assert observed == expected
+    diff = deepdiff.diff.DeepDiff(observed, expected)
+    assert diff == {}
 
 
 @pytest.mark.parametrize("bigstitcher_xml", (0, 1, 2, 3, 4, 5, 6), indirect=True)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -200,6 +200,7 @@ def test_decode_view_interest_points() -> None:
     assert diff_result == []
 
 
+@pytest.mark.parametrize("bigstitcher_xml", (0, 1, 2, 3, 4, 5), indirect=True)
 @pytest.mark.parametrize(
     "attribute_path, model_class",
     [
@@ -208,7 +209,6 @@ def test_decode_view_interest_points() -> None:
         ("ViewRegistrations", ViewRegistrations),
     ],
 )
-@pytest.mark.parametrize("bigstitcher_xml", (0, 1, 2, 3, 4, 5), indirect=True)
 def test_view_setups(bigstitcher_xml: str, attribute_path: str, model_class: BaseXmlModel) -> None:
     tree: etree.Element = ElementTree.fromstring(bigstitcher_xml)
     for part in attribute_path.split("/"):
@@ -258,3 +258,5 @@ def test_transform() -> None:
         stringify_tuple(map(str, flatten_hoaffine(tx.transform, axes_out=("x", "y", "z"))))
         == affine_str
     )
+
+


### PR DESCRIPTION
Hi @d-v-b , I finally played around a bit with this library :)

I was trying to parse the xml file of the dataset shared by @nvladimus here: https://forum.image.sc/t/are-there-publicly-available-mesospim-datasets-unprocessed/116020/9.

There were some things I got a bit stuck with, as the xml seems to be following a slightly different spec from the test files in this repo (it does seem to load just fine in BigStitcher / BigDataViewer). Notably the following:

### 1) zgroup

A zgroup occurs as

```xml
<zgroup setup="0" tp="0" path="s0-t0.zarr" indicies="0 0" />
```
instead of e.g.
```xml
<zgroup setup="0" timepoint="0">
  <path>tile_x_0000_y_0000_z_0000_ch_488.zarr</path>
</zgroup>
```
Not modeled differences that cause validation errors:
1. "tp" instead of "timepoint"
1. "path" is an attribute instead of an element.

Both "tp" and "path" are read with their specific names by BigDataViewer. Which I'm actually not understanding as https://github.com/bigdataviewer/bigdataviewer-omezarr seems to expect differently. But I'm not very familiar with Java and might be looking at the wrong place and missing things...

### 2) Additional elements

E.g.:
- `/SpimData/generatedBy`
- `/SpimData/SequenceDescription/ViewSetups/ViewSetup/camera`

These create validation errors as well (because of changing the xml order?).

### Question

What would you say would be a good way to deal with these differences while still making use of the nice pydantic models in this library?

I made some modifications [here](https://github.com/d-v-b/pydantic-bigstitcher/compare/main...m-albert:pydantic-bigstitcher:mesospim) until parsing worked fine, but have very limited experience with bigstitcher xml files (as well as parsing and validation using pydantic).

Thanks a lot for any comments / help 🙏

EDIT: I originally wanted to open an issue but accidentally created a PR 🙈. Happy to move it if you prefer!