### PR TITLE
Add zizmor to pre-commit and harden GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
       actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,14 +19,18 @@ jobs:
     name: py=${{ matrix.python-version }}
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,10 @@ repos:
     rev: v4.6.0
     hooks:
       - id: check-yaml
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.25.2
+    hooks:
+      - id: zizmor
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.11.2
     hooks:


### PR DESCRIPTION
## Summary

Adds [zizmor](https://docs.zizmor.sh) to the pre-commit checks to audit our GitHub Actions configuration, and resolves every finding it surfaces so the hook passes clean.

## Changes

- **`.pre-commit-config.yaml`** — Add the `zizmorcore/zizmor-pre-commit` hook (`v1.25.2`).
- **`.github/workflows/test.yml`** — Resolve zizmor findings:
  - `unpinned-uses` (high): pin `actions/checkout` and `actions/setup-python` to commit SHAs, with `# vX.Y.Z` comments that dependabot keeps updated.
  - `excessive-permissions` (medium): add least-privilege `permissions: contents: read` to the test job.
  - `artipacked` (low): set `persist-credentials: false` on checkout so `GITHUB_TOKEN` isn't persisted into the workspace.
- **`.github/dependabot.yml`** — Add a 7-day `cooldown` (zizmor safe auto-fix) to delay auto-adopting brand-new releases.

## Verification

`pre-commit run zizmor --all-files` → **Passed**.

## Notes

- The `# vX.Y.Z` comments after the pinned SHAs are required — dependabot reads them to keep both hash and comment current, and zizmor expects them. Don't strip them.
- Pre-existing, unrelated warnings remain (mutable `rev: ""` on `blacken-docs`/`mirrors-prettier`, deprecated `default_stages`). Out of scope here — happy to clean up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)