### PR TITLE
ci: fix release workflow startup_failure (test job permissions)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ permissions: {}
 
 jobs:
   test:
+    # The reusable test workflow's job requests `contents: read`; a called
+    # workflow cannot exceed the caller's grant, and the top-level default is
+    # `permissions: {}` (everything none). Grant it explicitly here.
+    permissions:
+      contents: read
     uses: ./.github/workflows/test.yml
 
   build:


### PR DESCRIPTION
## Problem

The `v0.0.11rc1` release run failed with **`startup_failure`** — the workflow never started a job. GitHub's error:

> `.github/workflows/release.yml (Line: 10, Col: 3): Error calling workflow '…/test.yml@…'. The nested job 'test' is requesting 'contents: read', but is only allowed 'contents: none'.`

## Cause

`release.yml` sets top-level `permissions: {}` (least-privilege: everything defaults to `none`). Its `test` job calls the reusable `test.yml`, whose job declares `permissions: contents: read` (added by the zizmor hardening). A **called workflow cannot request more permission than the caller grants** — the caller offered `contents: none`, the callee needs `contents: read`, so GitHub rejects the entire workflow at startup.

## Fix

Grant `contents: read` on the `test` job in `release.yml` (the job that does the `uses:` call). Everything else keeps the strict `permissions: {}` default.

```yaml
  test:
    permissions:
      contents: read
    uses: ./.github/workflows/test.yml
```

## Verification

- YAML validates; `test` job now grants `contents: read`.
- pre-commit (incl. zizmor) passes on `release.yml`.
- Scoped to `release.yml` only.

After merge, re-running the release (or re-publishing the release/tag) should get past startup and run the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
